### PR TITLE
Get it working on Azure App Service

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -174,8 +174,8 @@ Target "All" DoNothing
 // Should probably deploy pre-built assembly from AppVeyor instead.
 
 "AssemblyInfo"
-  ==> "Build"
   ==> "StageWebsiteAssets"
+  ==> "Build"
   ==> "Deploy"
 
 RunTargetOrDefault "All"

--- a/build.fsx
+++ b/build.fsx
@@ -90,7 +90,8 @@ Target "BuildVersion" <| fun _ ->
 // Clean build results & restore NuGet packages
 
 Target "Clean" <| fun _ ->
-    CleanDirs ["bin"]
+    CleanDir Kudu.deploymentTemp
+    DeleteDirs [ @"src\c4fsharp\bin"; @"src\c4fsharp\obj" ]
 
 // --------------------------------------------------------------------------------------
 // Build library & test project
@@ -102,7 +103,7 @@ Target "Build" <| fun _ ->
             Verbosity = Some Minimal
             Targets = [ "Build" ]
             Properties = [ "Configuration", "Release"
-                           "OutputPath", Kudu.deploymentTemp ] })
+                           "OutputPath", Kudu.deploymentTemp + @"\bin" ] })
     |> ignore
 
 
@@ -145,6 +146,7 @@ Target "StageWebsiteAssets" <| fun _ ->
     let blacklist =
         [ "typings"
           ".fs"
+          ".sln"
           "App.config"
           ".references"
           "tsconfig.json" ]
@@ -170,6 +172,8 @@ Target "All" DoNothing
   =?> ("SourceLink", Pdbstr.tryFind().IsSome )
 #endif
   ==> "All"
+
+"Clean" ==> "StageWebsiteAssets"
 
 // Should probably deploy pre-built assembly from AppVeyor instead.
 


### PR DESCRIPTION
There were a couple of issues with the FAKE script that I've fixed: -

1. The StageWebsiteAssets was happening *after* the Build stage. This had the unintended effect of actually copying across the bin and obj etc. files straight into wwwroot. You can check this by using the Kudu Console in the Azure App Service and getting a directory listing (and you can test it locally by checking what's in %temp%/kudutemp). I've swapped it so that the assets will get copied before the build.

2. The build now copies into the bin subfolder of the kudu temp folder.

I suspect that it was the combination of these two things that was breaking the deployment (although I can't confirm what exactly it was - but it now works for me).

I've also added a couple of things to the Clean stage to clean the deployment temp and delete bin and obj explicitly so there's no chance of them getting copied across.